### PR TITLE
Add hasComments method to Gist

### DIFF
--- a/app/Gists/Gist.php
+++ b/app/Gists/Gist.php
@@ -13,7 +13,7 @@ class Gist
     public $link;
     public $createdAt;
     public $updatedAt;
-    public $comments = [];
+    public $comments;
 
     public static function fromGitHub($githubGist, $githubComments = [])
     {
@@ -38,5 +38,10 @@ class Gist
     public function renderHtml()
     {
         return MarkdownExtra::defaultTransform($this->content);
+    }
+
+    public function hasComments()
+    {
+        return $this->comments->count() > 0;
     }
 }

--- a/resources/views/gistlogs/show.blade.php
+++ b/resources/views/gistlogs/show.blade.php
@@ -23,7 +23,7 @@
                         </div>
                     </div>
                 </div>
-                @if (count($gist->comments) > 0)
+                @if ($gist->hasComments())
                     <h3>Comments</h3>
 
                     @foreach ($gist->comments as $comment)

--- a/tests/GistTest.php
+++ b/tests/GistTest.php
@@ -43,4 +43,25 @@ class GistTest extends TestCase
         $this->assertCount(2, $gist->comments);
         $this->assertContainsOnlyInstancesOf(Comment::class, $gist->comments);
     }
+
+    /** @test */
+    public function it_has_comments_when_there_are_one_or_more_comments()
+    {
+        $githubGist = $this->loadFixture('002ed429c7c21ab89300.json');
+        $githubComments = $this->loadFixture('002ed429c7c21ab89300/comments.json');
+
+        $gist = Gist::fromGitHub($githubGist, $githubComments);
+
+        $this->assertTrue($gist->hasComments());
+    }
+
+    /** @test */
+    public function it_has_no_comments_when_there_are_zero_comments()
+    {
+        $githubGist = $this->loadFixture('002ed429c7c21ab89300.json');
+
+        $gist = Gist::fromGitHub($githubGist);
+
+        $this->assertFalse($gist->hasComments());
+    }
 }


### PR DESCRIPTION
Added mainly to make conditionals in templates more expressive.

Instead of saying `if (count($gist->comments) > 0)` we can just say `if
($gist->hasComments())`.
