### PR TITLE
Prevent secret gists from being indexed

### DIFF
--- a/app/Gists/Gist.php
+++ b/app/Gists/Gist.php
@@ -11,6 +11,7 @@ class Gist
     public $author;
     public $avatarUrl;
     public $link;
+    private $public;
 
     /**
      * @var Carbon
@@ -42,6 +43,7 @@ class Gist
         $gist->author = $githubGist['owner']['login'];
         $gist->avatarUrl = $githubGist['owner']['avatar_url'];
         $gist->link = $githubGist['html_url'];
+        $gist->public = $githubGist['public'];
         $gist->createdAt = Carbon::parse($githubGist['created_at']);
         $gist->updatedAt = Carbon::parse($githubGist['updated_at']);
 
@@ -66,5 +68,21 @@ class Gist
     public function hasComments()
     {
         return $this->comments->count() > 0;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPublic()
+    {
+        return $this->public;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSecret()
+    {
+        return ! $this->isPublic();
     }
 }

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -7,7 +7,7 @@
 	<title>Gistlog</title>
 
 	<link href="/css/app.css" rel="stylesheet">
-	@if (isset($secret) && $secret)
+	@if (isset($gist) && $gist->isSecret())
 	<meta name="robots" content="noindex, nofollow">
 	@endif
 

--- a/tests/GistTest.php
+++ b/tests/GistTest.php
@@ -64,4 +64,48 @@ class GistTest extends TestCase
 
         $this->assertFalse($gist->hasComments());
     }
+
+    /** @test */
+    public function secret_gists_are_not_public()
+    {
+        $githubGist = $this->loadFixture('002ed429c7c21ab89300.json');
+        $githubGist['public'] = false;
+
+        $gist = Gist::fromGitHub($githubGist);
+
+        $this->assertFalse($gist->isPublic());
+    }
+
+    /** @test */
+    public function public_gists_are_public()
+    {
+        $githubGist = $this->loadFixture('002ed429c7c21ab89300.json');
+        $githubGist['public'] = true;
+
+        $gist = Gist::fromGitHub($githubGist);
+
+        $this->assertTrue($gist->isPublic());
+    }
+
+    /** @test */
+    public function secret_gists_are_secret()
+    {
+        $githubGist = $this->loadFixture('002ed429c7c21ab89300.json');
+        $githubGist['public'] = false;
+
+        $gist = Gist::fromGitHub($githubGist);
+
+        $this->assertTrue($gist->isSecret());
+    }
+
+    /** @test */
+    public function public_gists_are_not_secret()
+    {
+        $githubGist = $this->loadFixture('002ed429c7c21ab89300.json');
+        $githubGist['public'] = true;
+
+        $gist = Gist::fromGitHub($githubGist);
+
+        $this->assertFalse($gist->isSecret());
+    }
 }


### PR DESCRIPTION
Reimplementing functionality that was lost in the Great Refactor, oops.
