### PR TITLE
Improve list styling

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -3772,10 +3772,6 @@ a.list-group-item-danger.active:focus {
   line-height: 1.7;
   padding: 1.2em;
 }
-.gistlog__content ul,
-.gistlog__content ol {
-  margin-bottom: 1.36363636em;
-}
 .gistlog__content ul > li,
 .gistlog__content ol > li {
   margin-bottom: 0.5em;
@@ -3783,6 +3779,10 @@ a.list-group-item-danger.active:focus {
 .gistlog__content ul > li:last-child,
 .gistlog__content ol > li:last-child {
   margin-bottom: 0;
+}
+.gistlog__content > ul,
+.gistlog__content > ol {
+  margin-bottom: 1.36363636em;
 }
 body,
 label,

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -3780,6 +3780,10 @@ a.list-group-item-danger.active:focus {
 .gistlog__content ol > li:last-child {
   margin-bottom: 0;
 }
+.gistlog__content ul > li > ul,
+.gistlog__content ol > li > ul {
+  margin-top: 0.5em;
+}
 .gistlog__content > ul,
 .gistlog__content > ol {
   margin-bottom: 1.36363636em;

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -3772,6 +3772,18 @@ a.list-group-item-danger.active:focus {
   line-height: 1.7;
   padding: 1.2em;
 }
+.gistlog__content ul,
+.gistlog__content ol {
+  margin-bottom: 1.36363636em;
+}
+.gistlog__content ul > li,
+.gistlog__content ol > li {
+  margin-bottom: 0.5em;
+}
+.gistlog__content ul > li:last-child,
+.gistlog__content ol > li:last-child {
+  margin-bottom: 0;
+}
 body,
 label,
 .checkbox label {

--- a/resources/assets/less/components/gistlog.less
+++ b/resources/assets/less/components/gistlog.less
@@ -47,6 +47,18 @@
       padding: 1.2em;
     }
   }
+
+  ul, ol {
+    margin-bottom: (30em/22em);
+
+    > li {
+      margin-bottom: 0.5em;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
 }
 
 .gistlog__meta {}

--- a/resources/assets/less/components/gistlog.less
+++ b/resources/assets/less/components/gistlog.less
@@ -49,7 +49,6 @@
   }
 
   ul, ol {
-    margin-bottom: (30em/22em);
 
     > li {
       margin-bottom: 0.5em;
@@ -58,6 +57,10 @@
         margin-bottom: 0;
       }
     }
+  }
+
+  > ul, > ol {
+    margin-bottom: (30em/22em);
   }
 }
 

--- a/resources/assets/less/components/gistlog.less
+++ b/resources/assets/less/components/gistlog.less
@@ -56,6 +56,10 @@
       &:last-child {
         margin-bottom: 0;
       }
+
+      > ul {
+        margin-top: 0.5em;
+      }
     }
   }
 


### PR DESCRIPTION
- Space out individual list items nicely
- Add bottom margin for entire lists that matches paragraph margin
- No bottom margin for nested lists

Still trying to figure out the best approach to styling all this type. Right now I don't mind this sort of hacky approach though. Get it looking basically how we want by whatever means necessary, then analyze what we ended up with and clean it up.

I noticed Medium uses a before pseudo-element for their bullets because a regular disc just didn't look quite good enough. Theirs definitely does look nicer than the default :) Something to consider if we want to get really nuts.

**Before:**

![Before](https://cloud.githubusercontent.com/assets/4323180/5995355/bbcdafb4-aa5e-11e4-8dc1-98264174f7de.png)

**After:**

![After](https://cloud.githubusercontent.com/assets/4323180/5995374/49baa610-aa5f-11e4-9f76-98df9478bf3e.png)
