### PR TITLE
waffle.io Badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/mattstauffer/gistlog.png?label=ready&title=Ready)](https://waffle.io/mattstauffer/gistlog)
 ## Gistlog 
 
 [![Build Status](https://travis-ci.org/mattstauffer/gistlog.png?branch=master)](http://travis-ci.org/mattstauffer/gistlog)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/mattstauffer/gistlog

This was requested by a real person (user mattstauffer) on waffle.io, we're not trying to spam you.
