### PR TITLE
Improve code block styling

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -705,7 +705,7 @@ code,
 kbd,
 pre,
 samp {
-  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+  font-family: Consolas, Menlo, Monaco, "Courier New", monospace;
 }
 code {
   padding: 2px 4px;
@@ -3539,17 +3539,22 @@ a.list-group-item-danger.active:focus {
 }
 .gistlog__content pre {
   background: none;
-  border: none;
-  border-radius: 0;
+  border: 1px solid #dddddd;
+  border-radius: 5px;
+  box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.1);
   font-size: 22px;
   margin-bottom: 1.36363636em;
   padding: 0;
 }
 .gistlog__content pre > code {
-  background-color: #f7f7f7;
+  background-color: #ffffff;
+  border-left: 3em solid #f0f0f0;
   font-size: 13px;
-  line-height: 1.7;
+  line-height: 1.5;
   padding: 1.2em;
+}
+.gistlog__content pre > code * {
+  font-weight: normal !important;
 }
 .comment {
   clear: left;

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -3551,10 +3551,23 @@ a.list-group-item-danger.active:focus {
   border-left: 3em solid #f0f0f0;
   font-size: 13px;
   line-height: 1.5;
-  padding: 1.2em;
+  padding-left: 1.5em;
 }
 .gistlog__content pre > code * {
   font-weight: normal !important;
+}
+.gistlog__content pre {
+  position: relative;
+  overflow-y: hidden;
+}
+.gistlog__content .line-numbers {
+  color: #aaaaaa;
+  font-size: 13px;
+  line-height: 1.5;
+  position: absolute;
+  text-align: right;
+  top: 0.5em;
+  width: 2em;
 }
 .comment {
   clear: left;

--- a/resources/assets/less/app.less
+++ b/resources/assets/less/app.less
@@ -13,6 +13,7 @@ html {
 
 @btn-font-weight: 300;
 @font-family-sans-serif: "Roboto", Helvetica, Arial, sans-serif;
+@font-family-monospace:   Consolas, Menlo, Monaco, "Courier New", monospace;
 
 /**
  * Bootstrap-esque

--- a/resources/assets/less/components/gistlog.less
+++ b/resources/assets/less/components/gistlog.less
@@ -67,11 +67,26 @@
             border-left: 3em solid rgb(240, 240, 240);
             font-size: 13px;
             line-height: 1.5;
-            padding: 1.2em;
+            padding-left: 1.5em;
             * {
                 font-weight: normal !important;
             }
         }
+    }
+
+    pre {
+        position: relative;
+        overflow-y: hidden;
+    }
+
+    .line-numbers {
+        color: rgb(170, 170, 170);
+        font-size: 13px;
+        line-height: 1.5;
+        position: absolute;
+        text-align: right;
+        top: 0.5em;
+        width: 2em;
     }
 }
 

--- a/resources/assets/less/components/gistlog.less
+++ b/resources/assets/less/components/gistlog.less
@@ -56,16 +56,21 @@
 
     pre {
         background: none;
-        border: none;
-        border-radius: 0;
+        border: 1px solid rgb(221, 221, 221);
+        border-radius: 5px;
+        box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.1);
         font-size: 22px;
         margin-bottom: (30em/22em);
         padding: 0;
         > code {
-            background-color: rgb(247, 247, 247);
+            background-color: rgb(255, 255, 255);
+            border-left: 3em solid rgb(240, 240, 240);
             font-size: 13px;
-            line-height: 1.7;
+            line-height: 1.5;
             padding: 1.2em;
+            * {
+                font-weight: normal !important;
+            }
         }
     }
 }

--- a/resources/views/gistlogs/show.blade.php
+++ b/resources/views/gistlogs/show.blade.php
@@ -9,7 +9,7 @@
         <article class="gistlog">
             <h1 class="gistlog__title">{{ $gistlog->title }}</h1>
 
-            <div class="gistlog__content">
+            <div class="gistlog__content js-gistlog-content">
                 {!! $gistlog->renderHtml() !!}
             </div>
             <div class="gistlog__meta">
@@ -32,4 +32,21 @@
 
 @section('scripts')
     <script>hljs.initHighlightingOnLoad();</script>
+    <script>
+    $(function() {
+        var preElement = $('.js-gistlog-content pre').each(function (index) {
+            var lineNumbers = '<div class="line-numbers">';
+            var numberOfLines = $(this).find('code').html().split(/\n/).length - 1;
+
+            for (var i = 1; i <= numberOfLines; i++) {
+                lineNumbers = lineNumbers + i.toString() + "\n";
+            }
+
+            lineNumbers = lineNumbers + '</div>';
+
+            $(this).append(lineNumbers);
+        });
+    });
+
+    </script>
 @endsection


### PR DESCRIPTION
Inspired by the new Laravel 5 landing page :) Didn't actually swap for Prism or add actual line numbers, but it still looks a million billion times better. Maybe do that in the future, maybe not. Ultimately we probably wanna customize an existing syntax theme and pull it in instead of overriding it with our own styles (especially crappy ones like `code * { font-weight: normal !important; }`) but improvement is improvement.

**Before:**

![Old code blocks](https://cloud.githubusercontent.com/assets/4323180/6046838/811acc78-ac73-11e4-8cb4-ecf721c7880f.png)

**After:**

![New code blocks](https://cloud.githubusercontent.com/assets/4323180/6046841/82ad5628-ac73-11e4-8eb3-a67933c0e46b.png)
