### PR TITLE
Render non-markdown posts in a big ol' code block

### DIFF
--- a/app/Gists/Gistlog.php
+++ b/app/Gists/Gistlog.php
@@ -64,7 +64,7 @@ class Gistlog
         if ($this->language === 'Markdown') {
             return MarkdownExtra::defaultTransform($this->content);
         }
-        return '<pre><code>' . $this->content . '</code></pre>';
+        return "<pre><code>" . $this->content . "\n</code></pre>";
     }
 
     /**

--- a/app/Gists/Gistlog.php
+++ b/app/Gists/Gistlog.php
@@ -8,6 +8,7 @@ class Gistlog
     public $id;
     public $title;
     public $content;
+    public $language;
     public $author;
     public $avatarUrl;
     public $link;
@@ -40,6 +41,7 @@ class Gistlog
         $gistlog->id = $githubGist['id'];
         $gistlog->title = $githubGist['description'];
         $gistlog->content = array_values($githubGist['files'])[0]['content'];
+        $gistlog->language = array_values($githubGist['files'])[0]['language'];
         $gistlog->author = $githubGist['owner']['login'];
         $gistlog->avatarUrl = $githubGist['owner']['avatar_url'];
         $gistlog->link = $githubGist['html_url'];
@@ -59,7 +61,10 @@ class Gistlog
      */
     public function renderHtml()
     {
-        return MarkdownExtra::defaultTransform($this->content);
+        if ($this->language === 'Markdown') {
+            return MarkdownExtra::defaultTransform($this->content);
+        }
+        return '<pre><code>' . $this->content . '</code></pre>';
     }
 
     /**

--- a/tests/GistlogTest.php
+++ b/tests/GistlogTest.php
@@ -108,4 +108,14 @@ class GistlogTest extends TestCase
 
         $this->assertFalse($gistlog->isSecret());
     }
+
+    /** @test */
+    public function code_only_posts_render_in_a_code_block()
+    {
+        $githubGist = $this->loadFixture('aac58f02ec1aaaad7f88.json');
+
+        $gistlog = Gistlog::fromGitHub($githubGist);
+
+        $this->assertEquals('<pre><code>' . $gistlog->content . '</code></pre>', $gistlog->renderHtml());
+    }
 }

--- a/tests/GistlogTest.php
+++ b/tests/GistlogTest.php
@@ -116,6 +116,6 @@ class GistlogTest extends TestCase
 
         $gistlog = Gistlog::fromGitHub($githubGist);
 
-        $this->assertEquals('<pre><code>' . $gistlog->content . '</code></pre>', $gistlog->renderHtml());
+        $this->assertEquals("<pre><code>" . $gistlog->content . "\n</code></pre>", $gistlog->renderHtml());
     }
 }

--- a/tests/fixtures/gists/aac58f02ec1aaaad7f88.json
+++ b/tests/fixtures/gists/aac58f02ec1aaaad7f88.json
@@ -1,0 +1,80 @@
+{
+  "url": "https://api.github.com/gists/aac58f02ec1aaaad7f88",
+  "forks_url": "https://api.github.com/gists/aac58f02ec1aaaad7f88/forks",
+  "commits_url": "https://api.github.com/gists/aac58f02ec1aaaad7f88/commits",
+  "id": "aac58f02ec1aaaad7f88",
+  "git_pull_url": "https://gist.github.com/aac58f02ec1aaaad7f88.git",
+  "git_push_url": "https://gist.github.com/aac58f02ec1aaaad7f88.git",
+  "html_url": "https://gist.github.com/aac58f02ec1aaaad7f88",
+  "files": {
+    "staticinterface.php": {
+      "filename": "staticinterface.php",
+      "type": "application/x-httpd-php",
+      "language": "PHP",
+      "raw_url": "https://gist.githubusercontent.com/adamwathan/aac58f02ec1aaaad7f88/raw/ca43ffa04c51af51a7c7f71a9ea9218ee92d0988/staticinterface.php",
+      "size": 455,
+      "truncated": false,
+      "content": "interface UserRepository\n{\n\tpublic function all();\n}\n\nclass User extends Eloquent implements UserRepository\n{\n\tpublic static function all(); // comes from Eloquent obviously, but yeah\n}\n\n$user = new User;\n\n // This works as an instance call, even though it's declared as static,\n // standard PHP behaviour, but PHP will complain that User isn't\n // implementing the interface, because the interface defines it as an\n // instance method. Grr!\n$user->all();"
+    }
+  },
+  "public": false,
+  "created_at": "2015-01-28T15:19:54Z",
+  "updated_at": "2015-01-28T15:19:55Z",
+  "description": "Static interface",
+  "comments": 0,
+  "user": null,
+  "comments_url": "https://api.github.com/gists/aac58f02ec1aaaad7f88/comments",
+  "owner": {
+    "login": "adamwathan",
+    "id": 4323180,
+    "avatar_url": "https://avatars.githubusercontent.com/u/4323180?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/adamwathan",
+    "html_url": "https://github.com/adamwathan",
+    "followers_url": "https://api.github.com/users/adamwathan/followers",
+    "following_url": "https://api.github.com/users/adamwathan/following{/other_user}",
+    "gists_url": "https://api.github.com/users/adamwathan/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/adamwathan/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/adamwathan/subscriptions",
+    "organizations_url": "https://api.github.com/users/adamwathan/orgs",
+    "repos_url": "https://api.github.com/users/adamwathan/repos",
+    "events_url": "https://api.github.com/users/adamwathan/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/adamwathan/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "forks": [
+
+  ],
+  "history": [
+    {
+      "user": {
+        "login": "adamwathan",
+        "id": 4323180,
+        "avatar_url": "https://avatars.githubusercontent.com/u/4323180?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/adamwathan",
+        "html_url": "https://github.com/adamwathan",
+        "followers_url": "https://api.github.com/users/adamwathan/followers",
+        "following_url": "https://api.github.com/users/adamwathan/following{/other_user}",
+        "gists_url": "https://api.github.com/users/adamwathan/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/adamwathan/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/adamwathan/subscriptions",
+        "organizations_url": "https://api.github.com/users/adamwathan/orgs",
+        "repos_url": "https://api.github.com/users/adamwathan/repos",
+        "events_url": "https://api.github.com/users/adamwathan/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/adamwathan/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "7a773cc9932e6e7716905c29e53e4cc8985babf6",
+      "committed_at": "2015-01-28T15:19:54Z",
+      "change_status": {
+        "total": 17,
+        "additions": 17,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/aac58f02ec1aaaad7f88/7a773cc9932e6e7716905c29e53e4cc8985babf6"
+    }
+  ]
+}


### PR DESCRIPTION
Resolves #30 

Something is funky with the JS line number insertion stuff where it's skipping the last number. Something to do with how code blocks are rendered by the markdown parser vs. how a raw code file comes back from GitHub.

Should fix, probably not worth holding up the merge though considering how terrible code-only posts look at the moment, haha...
