### PR TITLE
More tests for parsing GitHub usernames

### DIFF
--- a/app/Gists/MarkdownRenderable.php
+++ b/app/Gists/MarkdownRenderable.php
@@ -12,6 +12,6 @@ trait MarkdownRenderable {
             return '<a href="http://github.com/' . trim($item[0], '@') . '" target="_blank">' . $item[0] . '</a>';
         };
 
-        return trim(preg_replace_callback('/(?<=^|(?<=[^a-zA-Z0-9-_\.]))@([A-Za-z0-9]+)/', $createLinks, $html));
+        return trim(preg_replace_callback('/(?<=^|(?<=[^a-zA-Z0-9-_\.]))@([A-Za-z0-9\-]+)/', $createLinks, $html));
     }
 }

--- a/app/Gists/MarkdownRenderable.php
+++ b/app/Gists/MarkdownRenderable.php
@@ -12,6 +12,6 @@ trait MarkdownRenderable {
             return '<a href="http://github.com/' . trim($item[0], '@') . '" target="_blank">' . $item[0] . '</a>';
         };
 
-        return trim(preg_replace_callback('/(?<=^|(?<=[^a-zA-Z0-9-_\.]))@([A-Za-z0-9\-]+)/', $createLinks, $html));
+        return trim(preg_replace_callback('/(?<=^|(?<=[^a-zA-Z0-9-_\.]))@([A-Za-z0-9][A-Za-z0-9\-]*)/', $createLinks, $html));
     }
 }

--- a/app/Gists/MarkdownRenderable.php
+++ b/app/Gists/MarkdownRenderable.php
@@ -12,6 +12,6 @@ trait MarkdownRenderable {
             return '<a href="http://github.com/' . trim($item[0], '@') . '" target="_blank">' . $item[0] . '</a>';
         };
 
-        return trim(preg_replace_callback('/(?<=^|(?<=[^a-zA-Z0-9-_\.]))@([A-Za-z]+[A-Za-z0-9]+)/', $createLinks, $html));
+        return trim(preg_replace_callback('/(?<=^|(?<=[^a-zA-Z0-9-_\.]))@([A-Za-z0-9]+)/', $createLinks, $html));
     }
 }

--- a/tests/CommentTest.php
+++ b/tests/CommentTest.php
@@ -18,45 +18,4 @@ class CommentTest extends TestCase
         $this->assertEquals("https://avatars.githubusercontent.com/u/4323180?v=3", $comment->avatarUrl);
         $this->assertEquals(new DateTime('2015-01-31T14:54:23Z'), $comment->updatedAt);
     }
-
-    /** @test */
-    public function it_converts_github_usernames_into_links()
-    {
-        $obj = new MarkdownRenderableStub;
-
-        $this->assertEquals(
-            '<p>Hey <a href="http://github.com/kayladnls" target="_blank">@kayladnls</a></p>',
-            $obj->renderFromMarkdown('Hey @kayladnls')
-        );
-    }
-
-    /** @test */
-    public function it_doesnt_mistake_email_addresses_for_github_usernames()
-    {
-        $obj = new MarkdownRenderableStub;
-
-        $this->assertEquals(
-            '<p>My email is example@example.com</p>',
-            $obj->renderFromMarkdown('My email is example@example.com')
-        );
-    }
-
-    /** @test */
-    public function it_doesnt_include_trailing_characters_in_github_usernames_that_arent_valid_username_characters()
-    {
-        $obj = new MarkdownRenderableStub;
-
-        $this->assertEquals(
-            '<p>Hey <a href="http://github.com/kayladnls" target="_blank">@kayladnls</a>!</p>',
-            $obj->renderFromMarkdown('Hey @kayladnls!')
-        );
-    }
-
-
 }
-
-class MarkdownRenderableStub
-{
-    use Gistlog\Gists\MarkdownRenderable;
-}
-

--- a/tests/MarkdownRenderableTraitTest.php
+++ b/tests/MarkdownRenderableTraitTest.php
@@ -69,6 +69,17 @@ class MarkdownRenderableTraitTest extends TestCase
             $obj->renderFromMarkdown('Hey @-adamwathan')
         );
     }
+
+    /** @test */
+    public function github_usernames_can_be_a_single_character()
+    {
+        $obj = new MarkdownRenderableStub;
+
+        $this->assertEquals(
+            '<p>Hey <a href="http://github.com/A" target="_blank">@A</a></p>',
+            $obj->renderFromMarkdown('Hey @A')
+        );
+    }
 }
 
 class MarkdownRenderableStub

--- a/tests/MarkdownRenderableTraitTest.php
+++ b/tests/MarkdownRenderableTraitTest.php
@@ -80,6 +80,17 @@ class MarkdownRenderableTraitTest extends TestCase
             $obj->renderFromMarkdown('Hey @A')
         );
     }
+
+    /** @test */
+    public function github_username_can_be_the_first_string_in_the_content()
+    {
+        $obj = new MarkdownRenderableStub;
+
+        $this->assertEquals(
+            '<p><a href="http://github.com/adamwathan" target="_blank">@adamwathan</a></p>',
+            $obj->renderFromMarkdown('@adamwathan')
+        );
+    }
 }
 
 class MarkdownRenderableStub

--- a/tests/MarkdownRenderableTraitTest.php
+++ b/tests/MarkdownRenderableTraitTest.php
@@ -91,6 +91,32 @@ class MarkdownRenderableTraitTest extends TestCase
             $obj->renderFromMarkdown('@adamwathan')
         );
     }
+
+    /** @test */
+    public function github_username_can_be_in_brackets()
+    {
+        $obj = new MarkdownRenderableStub;
+
+        $this->assertEquals(
+            '<p>Adam Wathan (<a href="http://github.com/adamwathan" target="_blank">@adamwathan</a>)</p>',
+            $obj->renderFromMarkdown('Adam Wathan (@adamwathan)')
+        );
+
+        $this->assertEquals(
+            '<p>Adam Wathan [<a href="http://github.com/adamwathan" target="_blank">@adamwathan</a>]</p>',
+            $obj->renderFromMarkdown('Adam Wathan [@adamwathan]')
+        );
+
+        $this->assertEquals(
+            '<p>Adam Wathan {<a href="http://github.com/adamwathan" target="_blank">@adamwathan</a>}</p>',
+            $obj->renderFromMarkdown('Adam Wathan {@adamwathan}')
+        );
+
+        $this->assertEquals(
+            '<p>Adam Wathan &lt;<a href="http://github.com/adamwathan" target="_blank">@adamwathan</a>></p>',
+            $obj->renderFromMarkdown('Adam Wathan <@adamwathan>')
+        );
+    }
 }
 
 class MarkdownRenderableStub

--- a/tests/MarkdownRenderableTraitTest.php
+++ b/tests/MarkdownRenderableTraitTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use Gistlog\Gists\Comment;
+
+class MarkdownRenderableTraitTest extends TestCase
+{
+    /** @test */
+    public function it_converts_github_usernames_into_links()
+    {
+        $obj = new MarkdownRenderableStub;
+
+        $this->assertEquals(
+            '<p>Hey <a href="http://github.com/kayladnls" target="_blank">@kayladnls</a></p>',
+            $obj->renderFromMarkdown('Hey @kayladnls')
+        );
+    }
+
+    /** @test */
+    public function it_doesnt_mistake_email_addresses_for_github_usernames()
+    {
+        $obj = new MarkdownRenderableStub;
+
+        $this->assertEquals(
+            '<p>My email is example@example.com</p>',
+            $obj->renderFromMarkdown('My email is example@example.com')
+        );
+    }
+
+    /** @test */
+    public function it_doesnt_include_trailing_characters_in_github_usernames_that_arent_valid_username_characters()
+    {
+        $obj = new MarkdownRenderableStub;
+
+        $this->assertEquals(
+            '<p>Hey <a href="http://github.com/kayladnls" target="_blank">@kayladnls</a>!</p>',
+            $obj->renderFromMarkdown('Hey @kayladnls!')
+        );
+    }
+}
+
+class MarkdownRenderableStub
+{
+    use Gistlog\Gists\MarkdownRenderable;
+}

--- a/tests/MarkdownRenderableTraitTest.php
+++ b/tests/MarkdownRenderableTraitTest.php
@@ -58,6 +58,17 @@ class MarkdownRenderableTraitTest extends TestCase
             $obj->renderFromMarkdown('Hey @adam-wathan')
         );
     }
+
+    /** @test */
+    public function github_usernames_cannot_begin_with_a_dash()
+    {
+        $obj = new MarkdownRenderableStub;
+
+        $this->assertEquals(
+            '<p>Hey @-adamwathan</p>',
+            $obj->renderFromMarkdown('Hey @-adamwathan')
+        );
+    }
 }
 
 class MarkdownRenderableStub

--- a/tests/MarkdownRenderableTraitTest.php
+++ b/tests/MarkdownRenderableTraitTest.php
@@ -47,6 +47,17 @@ class MarkdownRenderableTraitTest extends TestCase
             $obj->renderFromMarkdown('Hey @1foo')
         );
     }
+
+    /** @test */
+    public function it_recognizes_github_usernames_that_include_dashes()
+    {
+        $obj = new MarkdownRenderableStub;
+
+        $this->assertEquals(
+            '<p>Hey <a href="http://github.com/adam-wathan" target="_blank">@adam-wathan</a></p>',
+            $obj->renderFromMarkdown('Hey @adam-wathan')
+        );
+    }
 }
 
 class MarkdownRenderableStub

--- a/tests/MarkdownRenderableTraitTest.php
+++ b/tests/MarkdownRenderableTraitTest.php
@@ -36,6 +36,17 @@ class MarkdownRenderableTraitTest extends TestCase
             $obj->renderFromMarkdown('Hey @kayladnls!')
         );
     }
+
+    /** @test */
+    public function it_recognizes_github_usernames_that_begin_with_a_number()
+    {
+        $obj = new MarkdownRenderableStub;
+
+        $this->assertEquals(
+            '<p>Hey <a href="http://github.com/1foo" target="_blank">@1foo</a></p>',
+            $obj->renderFromMarkdown('Hey @1foo')
+        );
+    }
 }
 
 class MarkdownRenderableStub


### PR DESCRIPTION
Added some more tests which caught a couple other edge cases. Also validating against GitHub's username validation rules which allow usernames to begin with a number, be a single character, and contain dashes as long as it's not the first character.

I wouldn't be surprised if we end up with more of these custom parsing rules that we add to the default Markdown transformation, so it might be cool to have our own `GistlogParser::transform()` where we can register an arbitrary amount of transformations that can each live in their own class. Then this GitHub username stuff would be it's own encapsulated transformer for example, and we can basically register it as middleware in our Gistlog transformer.
