### PR TITLE
Add author to Gistlog

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -3520,6 +3520,21 @@ tbody.collapse.in {
 @media (min-width: 768px) {
   .gistlog__title {
     font-size: 60px;
+  }
+}
+.gistlog__author {
+  font-size: 19px;
+  font-weight: 400;
+  margin-bottom: 0.5em;
+  margin-top: 0.75em;
+  color: #969696;
+}
+.gistlog__author a {
+  color: #4b4b4b;
+}
+@media (min-width: 768px) {
+  .gistlog__author {
+    font-size: 23px;
     margin-bottom: 1em;
   }
 }

--- a/resources/assets/less/components/gistlog.less
+++ b/resources/assets/less/components/gistlog.less
@@ -10,6 +10,22 @@
 
     @media (min-width: @screen-sm-min) {
         font-size: 60px;
+    }
+}
+
+.gistlog__author {
+    font-size: 19px;
+    font-weight: 400;
+    margin-bottom: 0.5em;
+    margin-top: 0.75em;
+    color: rgb(150, 150, 150);
+
+    a {
+        color: rgb(75, 75, 75);
+    }
+
+    @media (min-width: @screen-sm-min) {
+        font-size: 23px;
         margin-bottom: 1em;
     }
 }

--- a/resources/views/gistlogs/show.blade.php
+++ b/resources/views/gistlogs/show.blade.php
@@ -8,6 +8,7 @@
 
         <article class="gistlog">
             <h1 class="gistlog__title">{{ $gistlog->title }}</h1>
+            <h2 class="gistlog__author">by <a href="https://github.com/{{ $gistlog->author }}">{{ $gistlog->author }}</a></h2>
 
             <div class="gistlog__content js-gistlog-content">
                 {!! $gistlog->renderHtml() !!}


### PR DESCRIPTION
This PR adds a simple "by author" heading.

![screen shot 2015-02-23 at 10 30 12 pm](https://cloud.githubusercontent.com/assets/58970/6343280/8e774f4e-bbab-11e4-9955-4166210bfb03.png)
