### PR TITLE
Fix usernames in links double-linking

### DIFF
--- a/app/ContentParser/GitHubUsernameTransformer.php
+++ b/app/ContentParser/GitHubUsernameTransformer.php
@@ -4,7 +4,7 @@ class GitHubUsernameTransformer implements Transformer
 {
     public function transform($content)
     {
-        $pattern = '/\B@[a-zA-Z0-9][a-zA-Z0-9\-]*\b(?!<\/a>)/';
+        $pattern = '/\B@(?!\-)[a-zA-Z0-9\-]*(?![^<]*<\/a>)/';
 
         return trim(preg_replace_callback($pattern, function ($item) {
             return '<a href="http://github.com/' . trim($item[0], '@') . '" target="_blank">' . $item[0] . '</a>';

--- a/app/ContentParser/GitHubUsernameTransformer.php
+++ b/app/ContentParser/GitHubUsernameTransformer.php
@@ -4,7 +4,7 @@ class GitHubUsernameTransformer implements Transformer
 {
     public function transform($content)
     {
-        $pattern = '/(?<=^|(?<=[^a-zA-Z0-9-_\.]))@([A-Za-z0-9][A-Za-z0-9\-]*)/';
+        $pattern = '/\B@[a-zA-Z0-9][a-zA-Z0-9\-]*\b(?!<\/a>)/';
 
         return trim(preg_replace_callback($pattern, function ($item) {
             return '<a href="http://github.com/' . trim($item[0], '@') . '" target="_blank">' . $item[0] . '</a>';

--- a/tests/GitHubUsernameTransformerTest.php
+++ b/tests/GitHubUsernameTransformerTest.php
@@ -117,4 +117,15 @@ class GitHubUsernameTransformerTest extends TestCase
             $transformer->transform('Adam Wathan <@adamwathan>')
         );
     }
+
+    /** @test */
+    public function it_doesnt_convert_usernames_in_links()
+    {
+        $transformer = new GitHubUsernameTransformer;
+
+        $this->assertEquals(
+            'I am <a href="http://twitter.com/stauffermatt">@stauffermatt</a> on Twitter',
+            $transformer->transform('I am <a href="http://twitter.com/stauffermatt">@stauffermatt</a> on Twitter')
+        );
+    }
 }

--- a/tests/GitHubUsernameTransformerTest.php
+++ b/tests/GitHubUsernameTransformerTest.php
@@ -127,5 +127,10 @@ class GitHubUsernameTransformerTest extends TestCase
             'I am <a href="http://twitter.com/stauffermatt">@stauffermatt</a> on Twitter',
             $transformer->transform('I am <a href="http://twitter.com/stauffermatt">@stauffermatt</a> on Twitter')
         );
+
+        $this->assertEquals(
+            'I am <a href="http://twitter.com/michaeldyrynda">little known @michaeldyrynda</a> on Twitter',
+            $transformer->transform('I am <a href="http://twitter.com/michaeldyrynda">little known @michaeldyrynda</a> on Twitter')
+        );
     }
 }


### PR DESCRIPTION
For example, if I write in markdown:

``` markdown
I am [@stauffermatt](http://twitter.com/stauffermatt) on twitter
```

or in HTML:

``` html
I am <a href="http://twitter.com/stauffermatt">@stauffermatt</a> on Twitter
```

I expect the @stauffermatt to be ignored. 

Currently you get:

``` html
I am <a href="http://twitter.com/stauffermatt"><a href="http://github.com/stauffermatt" target="_blank">@stauffermatt</a></a> on Twitter
```

So far have only written failing test.
