### PR TITLE
Add temporary 'add comment' link to Gist comment box (addresses #7)

### DIFF
--- a/resources/views/gistlogs/show.blade.php
+++ b/resources/views/gistlogs/show.blade.php
@@ -18,7 +18,7 @@
                 Updated {{ $gistlog->updatedAt->diffForHumans() }}
             </div>
             <div class="gistlog__links">
-                <a href="{{ $gistlog->link }}">View on GitHub</a>
+                <a href="{{ $gistlog->link }}">View on GitHub</a> | <a href="{{ $gistlog->link }}#js-new-comment-form-actions">Comment</a>
             </div>
         </article>
         @if ($gistlog->hasComments())


### PR DESCRIPTION
Addresses, but doesn't fix, #7 (specifically https://github.com/tightenco/gistlog/issues/7#issuecomment-104701825)

![image](https://cloud.githubusercontent.com/assets/151829/7775400/d2ec752c-0080-11e5-8b69-2238988d1cb5.png)
