### PR TITLE
Don't autodetect language when highlighting code blocks

### DIFF
--- a/resources/views/gistlogs/show.blade.php
+++ b/resources/views/gistlogs/show.blade.php
@@ -32,8 +32,10 @@
 @endsection
 
 @section('scripts')
-    <script>hljs.initHighlightingOnLoad();</script>
     <script>
+    hljs.configure({ languages: [] });
+    hljs.initHighlightingOnLoad();
+
     $(function() {
         var preElement = $('.js-gistlog-content pre').each(function (index) {
             var lineNumbers = '<div class="line-numbers">';


### PR DESCRIPTION
Implemented by telling Highlight JS to only autodetect languages from a
specific list, which is an empty list in this case :)

Resolves #50.

Would be nicer if they had a more explicit configuration option.
