### PR TITLE
Add meta and OG

### DIFF
--- a/app/Gists/Gistlog.php
+++ b/app/Gists/Gistlog.php
@@ -91,4 +91,10 @@ class Gistlog
     {
         return ! $this->isPublic();
     }
+
+    public function getPreview()
+    {
+        $body = strip_tags($this->renderHtml());
+        return substr($body, 0, strpos($body, ' ', 200));
+    }
 }

--- a/resources/views/gistlogs/show.blade.php
+++ b/resources/views/gistlogs/show.blade.php
@@ -50,3 +50,16 @@
     });
     </script>
 @endsection
+
+@section('meta')
+        <!-- Schema.org markup for Google+ -->
+        <meta itemprop="name" content="{{ $gistlog->title }}">
+        <meta itemprop="description" content="{{ $gistlog->getPreview() }}">
+
+        <!-- Open Graph data -->
+        <meta property="og:title" content="{{ $gistlog->title }}">
+        <meta property="og:type" content="article">
+        <meta property="og:url" content="{{ Request::url() }}">
+        <meta property="og:description" content="{{ $gistlog->getPreview() }}">
+        <meta property="og:site_name" content="Gistlog">
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -6,6 +6,8 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>{{ isset($pageTitle) ? $pageTitle . ' | ' : '' }}Gistlog</title>
 
+	@yield ('meta')
+
 	<link href="/css/app.css" rel="stylesheet">
 	@if (isset($gistlog) && $gistlog->isSecret())
 	<meta name="robots" content="noindex, nofollow">


### PR DESCRIPTION
Fixes #47

Output::

```
            <!-- Schema.org markup for Google+ -->
        <meta itemprop="name" content="Introducing Gistlog landing pages">
        <meta itemprop="description" content="It&#039;s great that Gistlog makes it easy to write Gist-powered, Markdown-formatted, blog posts. But what if you want to use it as your entire blogging platform? We&#039;re working on it, and here&#039;s a first step:">

        <!-- Open Graph data -->
        <meta property="og:title" content="Introducing Gistlog landing pages">
        <meta property="og:type" content="article">
        <meta property="og:url" content="http://localhost:8095/mattstauffer/a82db51468a02f53442d">
        <meta property="og:description" content="It&#039;s great that Gistlog makes it easy to write Gist-powered, Markdown-formatted, blog posts. But what if you want to use it as your entire blogging platform? We&#039;re working on it, and here&#039;s a first step:">
        <meta property="og:site_name" content="Gistlog">

```
