### PR TITLE
Fix preview breaking for gistlog < 200 chars

### DIFF
--- a/app/Gists/Gistlog.php
+++ b/app/Gists/Gistlog.php
@@ -95,7 +95,11 @@ class Gistlog
     public function getPreview()
     {
         $body = strip_tags($this->renderHtml());
-        if(strlen($body) < 200) return $body;
+
+        if (strlen($body) < 200) {
+            return $body;
+        }
+
         return substr($body, 0, strpos($body, ' ', 200));
     }
 }

--- a/app/Gists/Gistlog.php
+++ b/app/Gists/Gistlog.php
@@ -95,6 +95,7 @@ class Gistlog
     public function getPreview()
     {
         $body = strip_tags($this->renderHtml());
+        if(strlen($body) < 200) return $body;
         return substr($body, 0, strpos($body, ' ', 200));
     }
 }


### PR DESCRIPTION
Should return full body of gistlog for a preview when the body length is less than the default preview length of 200.

reference Issue #61
