### PR TITLE
fix comments link to focus on new comment field when being clicked

### DIFF
--- a/resources/views/gistlogs/show.blade.php
+++ b/resources/views/gistlogs/show.blade.php
@@ -18,7 +18,7 @@
                 Updated {{ $gistlog->updatedAt->diffForHumans() }}
             </div>
             <div class="gistlog__links">
-                <a href="{{ $gistlog->link }}">View on GitHub</a> | <a href="{{ $gistlog->link }}#js-new-comment-form-actions">Comment</a>
+                <a href="{{ $gistlog->link }}">View on GitHub</a> | <a href="{{ $gistlog->link }}#new_comment_field">Comment</a>
             </div>
         </article>
         @if ($gistlog->hasComments())


### PR DESCRIPTION
The current comments link won't take you to the bottom of the page to comment on the gist. This will navigate you to the bottom of the page and focus you into the new comments field.
