### PR TITLE
wrap non-markdown docs with htmlspecialchars and pass their languages…

### DIFF
--- a/app/Gists/Gistlog.php
+++ b/app/Gists/Gistlog.php
@@ -68,7 +68,7 @@ class Gistlog
             return ContentParser::transform($this->content);
         }
 
-        return "<pre><code>" . $this->content . "\n</code></pre>";
+        return "<pre><code>" . htmlspecialchars($this->content) . "\n</code></pre>";
     }
 
     /**

--- a/resources/views/gistlogs/show.blade.php
+++ b/resources/views/gistlogs/show.blade.php
@@ -33,7 +33,7 @@
 
 @section('scripts')
     <script>
-    hljs.configure({ languages: [] });
+    hljs.configure({ languages: ['{{ strtolower($gistlog->language) }}'] });
     hljs.initHighlightingOnLoad();
 
     $(function() {


### PR DESCRIPTION
… to highlight.js
