### PR TITLE
Fix flash message positioning

### DIFF
--- a/resources/assets/less/components/notice.less
+++ b/resources/assets/less/components/notice.less
@@ -2,8 +2,6 @@
     border: 1px solid black;
     margin: 0 1em;
     padding: 0.5em;
-    position: absolute;
-    width: 80%;
     z-index: 999;
 
     &--info {


### PR DESCRIPTION
The flash message overlaps the header for an invalid or empty URL.

<img width="698" alt="screen shot 2015-08-19 at 11 13 31 pm" src="https://cloud.githubusercontent.com/assets/4240991/9364354/9e889a36-46cb-11e5-8eb9-a579fec872e8.png">

And the fix does this:
<img width="742" alt="screen shot 2015-08-19 at 11 19 24 pm" src="https://cloud.githubusercontent.com/assets/4240991/9364367/b306f5fc-46cb-11e5-995b-4e758026873e.png">

Also, why is the public/css directory under version control?
