### PR TITLE
Update regex to make tests pass

### DIFF
--- a/app/ContentParser/GitHubUsernameTransformer.php
+++ b/app/ContentParser/GitHubUsernameTransformer.php
@@ -4,7 +4,7 @@ class GitHubUsernameTransformer implements Transformer
 {
     public function transform($content)
     {
-        $pattern = '/\B@[a-zA-Z0-9][a-zA-Z0-9\-]*\b(?!<\/a>)/';
+        $pattern = '/\B@(?!\-)[a-zA-Z0-9\-]*(?![^<]*<\/a>)/';
 
         return trim(preg_replace_callback($pattern, function ($item) {
             return '<a href="http://github.com/' . trim($item[0], '@') . '" target="_blank">' . $item[0] . '</a>';

--- a/app/ContentParser/GitHubUsernameTransformer.php
+++ b/app/ContentParser/GitHubUsernameTransformer.php
@@ -4,7 +4,7 @@ class GitHubUsernameTransformer implements Transformer
 {
     public function transform($content)
     {
-        $pattern = '/(?<=^|(?<=[^a-zA-Z0-9-_\.]))@([A-Za-z0-9][A-Za-z0-9\-]*)/';
+        $pattern = '/\B@[a-zA-Z0-9][a-zA-Z0-9\-]*\b(?!<\/a>)/';
 
         return trim(preg_replace_callback($pattern, function ($item) {
             return '<a href="http://github.com/' . trim($item[0], '@') . '" target="_blank">' . $item[0] . '</a>';

--- a/tests/GitHubUsernameTransformerTest.php
+++ b/tests/GitHubUsernameTransformerTest.php
@@ -127,5 +127,10 @@ class GitHubUsernameTransformerTest extends TestCase
             'I am <a href="http://twitter.com/stauffermatt">@stauffermatt</a> on Twitter',
             $transformer->transform('I am <a href="http://twitter.com/stauffermatt">@stauffermatt</a> on Twitter')
         );
+
+        $this->assertEquals(
+            'I am <a href="http://twitter.com/michaeldyrynda">little known @michaeldyrynda</a> on Twitter',
+            $transformer->transform('I am <a href="http://twitter.com/michaeldyrynda">little known @michaeldyrynda</a> on Twitter')
+        );
     }
 }


### PR DESCRIPTION
This modification does make all of your tests pass, however, if you add the following assertion:

``` php
$this->assertEquals(
    'I am <a href="http://twitter.com/stauffermatt">@stauffermatt and I am big</a> on Twitter',
    $transformer->transform('I am <a href="http://twitter.com/stauffermatt">@stauffermatt and I am big</a> on Twitter')
);
```

You'll wind up with the same issue again. There's loads of edge cases with this, there must be a _right_ way of doing it (Github gets it right, after all), but the rabbit hole is deep.
