### PR TITLE
Add XSS cleaner

### DIFF
--- a/app/ContentParser/XssCleaner.php
+++ b/app/ContentParser/XssCleaner.php
@@ -11,7 +11,6 @@ class XssCleaner implements Transformer
         $config->tagWhiteList = array_merge($config->tagWhiteList, [
             'code' => ['class' => true],
             'pre' => [],
-            'style' => [],
         ]);
         return (new Stauros($config))->scanHTML($content);
     }

--- a/app/ContentParser/XssCleaner.php
+++ b/app/ContentParser/XssCleaner.php
@@ -1,11 +1,17 @@
 <?php namespace Gistlog\ContentParser;
 
+use Stauros\HTML\Config;
 use Stauros\Stauros;
 
 class XssCleaner implements Transformer
 {
     public function transform($content)
     {
-        return (new Stauros)->scanHTML($content);
+        $config = new Config;
+        $config->tagWhiteList = array_merge($config->tagWhiteList, [
+            'code' => ['class' => true],
+            'pre' => [],
+        ]);
+        return (new Stauros($config))->scanHTML($content);
     }
 }

--- a/app/ContentParser/XssCleaner.php
+++ b/app/ContentParser/XssCleaner.php
@@ -11,6 +11,7 @@ class XssCleaner implements Transformer
         $config->tagWhiteList = array_merge($config->tagWhiteList, [
             'code' => ['class' => true],
             'pre' => [],
+            'style' => [],
         ]);
         return (new Stauros($config))->scanHTML($content);
     }

--- a/app/ContentParser/XssCleaner.php
+++ b/app/ContentParser/XssCleaner.php
@@ -1,0 +1,11 @@
+<?php namespace Gistlog\ContentParser;
+
+use Stauros\Stauros;
+
+class XssCleaner implements Transformer
+{
+    public function transform($content)
+    {
+        return (new Stauros)->scanHTML($content);
+    }
+}

--- a/app/Providers/ContentParserServiceProvider.php
+++ b/app/Providers/ContentParserServiceProvider.php
@@ -5,6 +5,7 @@ namespace Gistlog\Providers;
 use Gistlog\ContentParser\ContentParser;
 use Gistlog\ContentParser\GitHubUsernameTransformer;
 use Gistlog\ContentParser\MarkdownTransformer;
+use Gistlog\ContentParser\XssCleaner;
 use Illuminate\Support\ServiceProvider;
 
 class ContentParserServiceProvider extends ServiceProvider {
@@ -21,6 +22,7 @@ class ContentParserServiceProvider extends ServiceProvider {
 
             $parser->push(new MarkdownTransformer);
             $parser->push(new GitHubUsernameTransformer);
+            $parser->push(new XssCleaner);
 
             return $parser;
         });

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
 		"laravel/framework": "5.0.*@dev",
 		"michelf/php-markdown": "~1.4",
 		"knplabs/github-api": "~1.4",
-		"symfony/yaml": "~2.6"
+		"symfony/yaml": "~2.6",
+		"ircmaxell/stauros": "dev-master#aa765e7fabdfe2487e4c5860e55615b78a042231"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1fc219851d6ceb31836925bf895ab8f7",
+    "hash": "ab318325bbc7f1d981fd1e10e22a6b6f",
     "packages": [
         {
             "name": "classpreloader/classpreloader",
@@ -355,6 +355,46 @@
                 "password"
             ],
             "time": "2014-11-20 16:49:30"
+        },
+        {
+            "name": "ircmaxell/stauros",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ircmaxell/Stauros.git",
+                "reference": "aa765e7fabdfe2487e4c5860e55615b78a042231"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ircmaxell/Stauros/zipball/b3daa234835a11897d530b0c4a66dd719ad10eef",
+                "reference": "aa765e7fabdfe2487e4c5860e55615b78a042231",
+                "shasum": ""
+            },
+            "require": {
+                "php-64bit": ">=5.5"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.*",
+                "phpunit/phpunit": "^4.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Stauros\\": "lib/Stauros/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anthony Ferrara",
+                    "email": "ircmaxell@gmail.com"
+                }
+            ],
+            "description": "A fast XSS cleaner for PHP",
+            "time": "2015-09-02 02:52:50"
         },
         {
             "name": "jakub-onderka/php-console-color",
@@ -2990,7 +3030,8 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "laravel/framework": 20
+        "laravel/framework": 20,
+        "ircmaxell/stauros": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,


### PR DESCRIPTION
Locked to most recent commit right now because composer wants to pull
in a broken commit by default, even at dev-master. Kind of weird.

Once there's a tag or composer is actually pulling in the most recent
commit, we can drop that.

Test with this gist `adamwathan/b6450affd3e2cacde13d` :)
