### PR TITLE
Change from AUTH_HTTP_TOKEN to AUTH_URL_CLIENT_ID 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,5 @@ CACHE_DRIVER=file
 SESSION_DRIVER=file
 
 GITHUB_TOKEN=your-github-token
+GITHUB_CLIENT_ID=your-github-client-id
+GITHUB_CLIENT_SECRET=your-github-client-secret

--- a/app/Providers/GistClientServiceProvider.php
+++ b/app/Providers/GistClientServiceProvider.php
@@ -23,8 +23,9 @@ class GistClientServiceProvider extends ServiceProvider
             // but if they aren't, no big deal.
             if (config('services.github.client_id') && config('services.github.client_secret')) {
                 $githubClient->authenticate(
-                    config('services.github.token'),
-                    GitHubClient::AUTH_HTTP_TOKEN
+                    config('services.github.client_id'),
+                    config('services.github.client_secret'),
+                    GitHubClient::AUTH_URL_CLIENT_ID
                 );
             }
 

--- a/config/services.php
+++ b/config/services.php
@@ -15,8 +15,8 @@ return [
     */
 
     'github' => [
-        // 'client_id' => env('GITHUB_CLIENT_ID'),
-        // 'client_secret' => env('GITHUB_CLIENT_SECRET'),
+        'client_id' => env('GITHUB_CLIENT_ID'),
+        'client_secret' => env('GITHUB_CLIENT_SECRET'),
         'token' => env('GITHUB_TOKEN'),
     ],
 ];


### PR DESCRIPTION
Updated auth method in GistClientServiceProvider from AUTH_HTTP_TOKEN to AUTH_URL_CLIENT_ID as suggested by @JacobBennett in PR #83.

Also uncommented client_id and client_secret lines in config/services.php as well as added placeholders to .env.example.
