### PR TITLE
Resolve case where a bare at-symbol will be transformed to a URL

### DIFF
--- a/app/ContentParser/GitHubUsernameTransformer.php
+++ b/app/ContentParser/GitHubUsernameTransformer.php
@@ -4,7 +4,7 @@ class GitHubUsernameTransformer implements Transformer
 {
     public function transform($content)
     {
-        $pattern = '/\B@(?!\-)[a-zA-Z0-9\-]*(?![^<]*<\/a>)/';
+        $pattern = '/\B@(?!\-)[a-zA-Z0-9\-]+(?![^<]*<\/a>)/';
 
         return trim(preg_replace_callback($pattern, function ($item) {
             return '<a href="http://github.com/' . trim($item[0], '@') . '" target="_blank">' . $item[0] . '</a>';

--- a/tests/GistlogTest.php
+++ b/tests/GistlogTest.php
@@ -116,6 +116,6 @@ class GistlogTest extends TestCase
 
         $gistlog = Gistlog::fromGitHub($githubGist);
 
-        $this->assertEquals("<pre><code>" . $gistlog->content . "\n</code></pre>", $gistlog->renderHtml());
+        $this->assertEquals("<pre><code>" . htmlspecialchars($gistlog->content) . "\n</code></pre>", $gistlog->renderHtml());
     }
 }

--- a/tests/GitHubUsernameTransformerTest.php
+++ b/tests/GitHubUsernameTransformerTest.php
@@ -133,4 +133,16 @@ class GitHubUsernameTransformerTest extends TestCase
             $transformer->transform('I am <a href="http://twitter.com/michaeldyrynda">little known @michaeldyrynda</a> on Twitter')
         );
     }
+
+
+    /** @test */
+    public function it_doesnt_match_an_at_symbol_on_its_own()
+    {
+        $transformer = new GitHubUsernameTransformer;
+
+        $this->assertEquals(
+            'Meet me @ the place',
+            $transformer->transform('Meet me @ the place')
+        );
+    }
 }


### PR DESCRIPTION
I came across this on another project using the transformer regular
expression where it was incorrectly matching a bare at-symbol and
subsequently transforming the URL.

I've updated the regex and added a test for this new case.
