### PR TITLE
Fix overflow-x issue when code block doesn't define a language

### DIFF
--- a/resources/assets/less/app.less
+++ b/resources/assets/less/app.less
@@ -58,3 +58,7 @@ code {
     white-space: pre-wrap;
     word-wrap: break-word;
 }
+
+pre code {
+    white-space: pre;
+}


### PR DESCRIPTION
## Before

<img width="706" alt="before" src="https://cloud.githubusercontent.com/assets/2998029/12869588/6bd545c8-cd24-11e5-8b41-6fe4adcd63ef.png">
## After

<img width="703" alt="screen shot 2016-02-06 at 22 49 15" src="https://cloud.githubusercontent.com/assets/2998029/12869591/77eb6cc0-cd24-11e5-99c7-81db888d96cd.png">
