### PR TITLE
Allow anonymous gists to be used.

### DIFF
--- a/app/Authors/Author.php
+++ b/app/Authors/Author.php
@@ -37,6 +37,20 @@ class Author
         return $author;
     }
 
+    public static function getAnonymous()
+    {
+        $author = new self;
+
+        $author->id = 0;
+        $author->avatarUrl = 'https://avatars3.githubusercontent.com/u/148100?v=3&s=400';
+        $author->link = 'https://github.com/anonymous';
+        $author->name = 'anonymous';
+        $author->username = 'anonymous';
+        $author->gists = collect();
+
+        return $author;
+    }
+
     /**
      * @return bool
      */

--- a/resources/views/gistlogs/show.blade.php
+++ b/resources/views/gistlogs/show.blade.php
@@ -2,13 +2,24 @@
 
 @section('content')
     <div class="container">
-        <a href="https://github.com/{{ $gistlog->author }}" class="profile-pic">
-            <img src="{{ $gistlog->avatarUrl }}">
-        </a>
+        @if($gistlog->isAnonymous())
+            <span class="profile-pic">
+                <img src="{{ $gistlog->avatarUrl }}">
+            </span>
+        @else
+            <a href="https://github.com/{{ $gistlog->author }}" class="profile-pic">
+                <img src="{{ $gistlog->avatarUrl }}">
+            </a>
+        @endif
 
         <article class="gistlog">
             <h1 class="gistlog__title">{{ $gistlog->title }}</h1>
-            <span class="gistlog__author">By <a href="/{{ $gistlog->author }}">{{ $gistlog->author }}</a></span>
+            @if($gistlog->isAnonymous())
+                <span class="gistlog__author">By {{ $gistlog->author }}</span>
+            @else
+                <span class="gistlog__author">By <a href="/{{ $gistlog->author }}">{{ $gistlog->author }}</a></span>
+            @endif
+
 
             <div class="gistlog__content js-gistlog-content">
                 {!! $gistlog->renderHtml() !!}

--- a/tests/GistlogTest.php
+++ b/tests/GistlogTest.php
@@ -118,4 +118,14 @@ class GistlogTest extends TestCase
 
         $this->assertEquals("<pre><code>" . htmlspecialchars($gistlog->content) . "\n</code></pre>", $gistlog->renderHtml());
     }
+
+    /** @test */
+    public function it_accepts_anonymous_gists()
+    {
+        $githubGist = $this->loadFixture('2c2769b21e512eabdd72.json');
+
+        $gistlog = Gistlog::fromGitHub($githubGist);
+
+        $this->assertEquals("anonymous", $gistlog->author);
+    }
 }

--- a/tests/fixtures/gists/2c2769b21e512eabdd72.json
+++ b/tests/fixtures/gists/2c2769b21e512eabdd72.json
@@ -1,0 +1,63 @@
+
+{
+    "url": "https://api.github.com/gists/2c2769b21e512eabdd72",
+    "forks_url": "https://api.github.com/gists/2c2769b21e512eabdd72/forks",
+    "commits_url": "https://api.github.com/gists/2c2769b21e512eabdd72/commits",
+    "id": "2c2769b21e512eabdd72",
+    "git_pull_url": "https://gist.github.com/2c2769b21e512eabdd72.git",
+    "git_push_url": "https://gist.github.com/2c2769b21e512eabdd72.git",
+    "html_url": "https://gist.github.com/2c2769b21e512eabdd72",
+    "files": {
+        "test.md": {
+            "filename": "test.md",
+            "type": "text/plain",
+            "language": "Markdown",
+            "raw_url": "https://gist.githubusercontent.com/anonymous/2c2769b21e512eabdd72/raw/30d74d258442c7c65512eafab474568dd706c430/test.md",
+            "size": 4,
+            "truncated": false,
+            "content": "test"
+        }
+    },
+    "public": false,
+    "created_at": "2016-02-03T20:59:00Z",
+    "updated_at": "2016-02-03T20:59:02Z",
+    "description": "",
+    "comments": 0,
+    "user": null,
+    "comments_url": "https://api.github.com/gists/2c2769b21e512eabdd72/comments",
+    "forks": [
+
+    ],
+    "history": [
+        {
+            "user": {
+                "login": "invalid-email-address",
+                "id": 148100,
+                "avatar_url": "https://avatars.githubusercontent.com/u/148100?v=3",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/invalid-email-address",
+                "html_url": "https://github.com/invalid-email-address",
+                "followers_url": "https://api.github.com/users/invalid-email-address/followers",
+                "following_url": "https://api.github.com/users/invalid-email-address/following{/other_user}",
+                "gists_url": "https://api.github.com/users/invalid-email-address/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/invalid-email-address/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/invalid-email-address/subscriptions",
+                "organizations_url": "https://api.github.com/users/invalid-email-address/orgs",
+                "repos_url": "https://api.github.com/users/invalid-email-address/repos",
+                "events_url": "https://api.github.com/users/invalid-email-address/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/invalid-email-address/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "version": "4e1a1c0867292639ce5a1b393866d7f344f1e4d0",
+            "committed_at": "2016-02-03T20:59:00Z",
+            "change_status": {
+                "total": 1,
+                "additions": 1,
+                "deletions": 0
+            },
+            "url": "https://api.github.com/gists/2c2769b21e512eabdd72/4e1a1c0867292639ce5a1b393866d7f344f1e4d0"
+        }
+    ],
+    "truncated": false
+}


### PR DESCRIPTION
Allow anonymous gists to be viewed. This addresses issue #92. 

The avatar currently references this GitHub user https://github.com/invalid-email-address.

If the gist is anonymous the author links to GitHub are removed. Here's a little preview using the Gist mentions in the issue.

![](https://i.gyazo.com/ca09ca72d7b444a2983f6b4052d24fb7.png)
