### PR TITLE
Fix `code` being displayed too big in lists

### DIFF
--- a/resources/assets/less/components/gistlog.less
+++ b/resources/assets/less/components/gistlog.less
@@ -103,7 +103,7 @@
         margin-bottom: (30em/22em);
     }
 
-    p > code {
+    p > code, li > code {
         border-radius: 0;
         font-size: 70%;
     }


### PR DESCRIPTION
Fix for issue #99
