### PR TITLE
Possible SEO tweak - remove 'robots' meta tag

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -9,9 +9,6 @@
     @yield ('meta')
 
     <link href="/css/app.css" rel="stylesheet">
-    @if (isset($gistlog) && $gistlog->isSecret())
-    <meta name="robots" content="noindex, nofollow">
-    @endif
 
     <!-- Fonts -->
     <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Roboto:300,400,700/Linux+Libertine:400,400i,700,700i">


### PR DESCRIPTION
Ok, this is merely a pull request as discussion. I'm not saying this should be a thing - more a thinking piece.

Currently on GitHub...

[Public Gists ARE Google Indexable](https://gist.github.com/timacdonald/96dbbc69c11d020e4cb7f5fbd81df531) - No `robots` meta tag.
[Private Gists are NOT Google Indexable](https://gist.github.com/timacdonald/10d5fa7a6c64e7ed01ef2fb200878099) - `noindex, follow`

Now if you throw these into GistLog

[Public Gists - Indexable](https://gistlog.co/timacdonald/96dbbc69c11d020e4cb7f5fbd81df531)
[Private Gist - NOT indexable](https://gistlog.co/timacdonald/10d5fa7a6c64e7ed01ef2fb200878099)

Okay, so this makes sense so far - but consider this. Google penalises duplicate content, so if you have a public Gist Google will see it on GitHub and GistLog. Obviously I don't know the inner workings of the Google Algorithm, but I dare say they are gonna pick GitHub as the source of truth and GistLog as a piggy backer.

My suggestion is to ditch the GistLog `robots` meta tag all together, so that we can create private Gists that Google won't index on GitHub, but WILL index on GistLog with no duplicate content issues.

Just a suggestion. Thoughts, ideas, pointless?