### PR TITLE
Check if the variables are set in the 404 view.

### DIFF
--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -28,7 +28,7 @@
     <h1>Unable to find your request</h1>
     <div class="button-container">
         <a href="{{ route('home') }}" class="button">Go back home</a>
-        @if ($gistId && $username)
+        @if (isset($gistId) && isset($username))
             <a href="{{ route('authors.show', ['username' => $username]) }}" class="button">Go to author page</a>
         @endif
     </div>


### PR DESCRIPTION
**CURRENT ERROR**
<img width="1084" alt="screen shot 2018-08-29 at 9 56 48 am" src="https://user-images.githubusercontent.com/15817188/44799981-86251a00-ab72-11e8-86a9-f81ab48b36e3.png">

**STEPS TO REPRODUCE**
- visit https://gistlog.co/mattstauffer/1c76d40371b295184845sdfdsfds (gits doesn't exist)

Currently when visiting a gist that doesn't exists, we `abort(404, 'Gist not found');` which loads the 404 view. 

It fails at the moment because the 404 view uses the `$gistId` and `$username`  variables which aren't passed along on the `GistNotFoundException` exception.

🤠