### PR TITLE
Prevent Vue code within Gists and comments from rendering

### DIFF
--- a/resources/views/create.blade.php
+++ b/resources/views/create.blade.php
@@ -39,7 +39,7 @@
         >
         <div class="flex justify-between my-1">
             <small
-                class="inline-block text-left text-blue-darker font-bold"
+                class="inline-block text-left text-blue-darker font-bold cursor-pointer"
                 onclick="copyToClipboard()"
             >Copy</small>
 

--- a/resources/views/gistlogs/comment.blade.php
+++ b/resources/views/gistlogs/comment.blade.php
@@ -8,7 +8,7 @@
             &bull; <a href="{{ $comment->link() }}" class="no-underline"
                 >{{ $comment->updatedAt->diffForHumans() }}</a>
         </span>
-        <span class="font-normal text-sm leading-normal text-justify">
+        <span class="font-normal text-sm leading-normal text-justify" v-pre>
                 {!! $comment->renderHtml() !!}
         </span>
     </div>

--- a/resources/views/gistlogs/show.blade.php
+++ b/resources/views/gistlogs/show.blade.php
@@ -26,7 +26,7 @@
             </a>
         </div>
     @endif
-    <div class="gistlog py-8 sm:px-8">
+    <div class="gistlog py-8 sm:px-8" v-pre>
         <article class="my-8 px-4 sm:px-8 my-8">
             <h1 class="gistlog__title">{{ $gistlog->title }}</h1>
             <span class="font-light mx-auto table">


### PR DESCRIPTION
### Changes

1. Use `v-pre` to prevent Vue code within Gists and comments from rendering
2. Update `copy to clipboard` link to use cursor-pointer.