### PR TITLE
Handle lengthy URLs within Gist content

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -7183,6 +7183,7 @@ pre code {
 
 .gistlog__content li {
   margin-bottom: 1rem;
+  overflow-wrap: break-word;
 }
 
 .gistlog__content ol {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2232,7 +2232,7 @@ __webpack_require__.r(__webpack_exports__);
         _this.comments = response.data;
         _this.loading = false;
       })["catch"](function () {
-        alert('Something went wrong.');
+        alert('Something went wrong loading the comments.');
       });
     }
   }
@@ -50251,9 +50251,9 @@ __webpack_require__.r(__webpack_exports__);
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-__webpack_require__(/*! /Users/mattstauffer/Sites/gistlog/resources/js/app.js */"./resources/js/app.js");
-__webpack_require__(/*! /Users/mattstauffer/Sites/gistlog/resources/less/landing.less */"./resources/less/landing.less");
-module.exports = __webpack_require__(/*! /Users/mattstauffer/Sites/gistlog/resources/less/app.less */"./resources/less/app.less");
+__webpack_require__(/*! /Users/ant/Sites/tighten/gistlog/resources/js/app.js */"./resources/js/app.js");
+__webpack_require__(/*! /Users/ant/Sites/tighten/gistlog/resources/less/landing.less */"./resources/less/landing.less");
+module.exports = __webpack_require__(/*! /Users/ant/Sites/tighten/gistlog/resources/less/app.less */"./resources/less/app.less");
 
 
 /***/ })

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -34,7 +34,7 @@
     max-width: 612px;
 
     a {
-        @apply break-all .no-underline;
+        @apply .no-underline;
 
         color: #037cc2;
     }

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -34,7 +34,7 @@
     max-width: 612px;
 
     a {
-        @apply .no-underline;
+        @apply .break-all .no-underline;
 
         color: #037cc2;
     }
@@ -70,6 +70,7 @@
 
     li {
         @apply .mb-4;
+        @apply .break-words;
     }
 
     ol {


### PR DESCRIPTION
This PR removes an incorrect style attribute for anchor tags nested underneath `.gistlog_content`.

| With `break-all` | Without `break-all` |
| --- | ---|
| ![Screen Shot 2019-08-09 at 4 19 22 PM](https://user-images.githubusercontent.com/487612/62809808-a323d600-bac1-11e9-85e7-911bfdbcb117.jpg) | ![Screen Shot 2019-08-09 at 4 19 08 PM](https://user-images.githubusercontent.com/487612/62809818-ab7c1100-bac1-11e9-8d76-8acb46a48e59.jpg)

