### PR TITLE
Fix lengthy URLs in Gists for Firefox

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -7127,6 +7127,7 @@ pre code {
 }
 
 .gistlog__content a {
+  display: block;
   word-break: break-all;
   text-decoration: none;
   color: #037cc2;

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -34,7 +34,7 @@
     max-width: 612px;
 
     a {
-        @apply .break-all .no-underline;
+        @apply .block .break-all .no-underline;
 
         color: #037cc2;
     }


### PR DESCRIPTION
References #151 

This PR adds `display: block` to URLs in Gists. This is needed for Firefox in order to properly break and wrap the URL.

Firefox
<img width="1218" alt="Screen Shot 2019-08-23 at 2 04 42 PM" src="https://user-images.githubusercontent.com/487612/63617572-6969c980-c5af-11e9-91b5-6632205a97cd.png">

Safari
<img width="963" alt="Screen Shot 2019-08-23 at 2 05 08 PM" src="https://user-images.githubusercontent.com/487612/63617584-72f33180-c5af-11e9-8622-77573bf60641.png">
