### PR TITLE
Update GitHub authentication methods.

### DIFF
--- a/app/Providers/AuthorClientServiceProvider.php
+++ b/app/Providers/AuthorClientServiceProvider.php
@@ -19,10 +19,11 @@ class AuthorClientServiceProvider extends ServiceProvider
             // authenticate, but doing so significantly increases the rate limit.
             // So here we authenticate if credentials are provided, but if not,
             // no big deal.
-            if (config('services.github.token')) {
+            if (config('services.github.client_id') && config('services.github.client_secret')) {
                 $githubClient->authenticate(
-                    config('services.github.token'),
-                    GitHubClient::AUTH_HTTP_TOKEN
+                    config('services.github.client_id'),
+                    config('services.github.client_secret'),
+                    GitHubClient::AUTH_HTTP_PASSWORD
                 );
             }
 

--- a/app/Providers/GistClientServiceProvider.php
+++ b/app/Providers/GistClientServiceProvider.php
@@ -18,7 +18,7 @@ class GistClientServiceProvider extends ServiceProvider
             // authenticate, but doing so significantly increases the rate
             // limit. So here we authenticate if credentials are provided,
             // but if they aren't, no big deal.
-            if (config('services.github.token')) {
+            if (config('services.github.client_id') && config('services.github.client_secret')) {
                 $githubClient->authenticate(
                     config('services.github.client_id'),
                     config('services.github.client_secret'),

--- a/app/Providers/GistClientServiceProvider.php
+++ b/app/Providers/GistClientServiceProvider.php
@@ -22,7 +22,7 @@ class GistClientServiceProvider extends ServiceProvider
                 $githubClient->authenticate(
                     config('services.github.client_id'),
                     config('services.github.client_secret'),
-                    GitHubClient::AUTH_URL_CLIENT_ID
+                    GitHubClient::AUTH_HTTP_PASSWORD
                 );
             }
 

--- a/app/Providers/GitHubClientServiceProvider.php
+++ b/app/Providers/GitHubClientServiceProvider.php
@@ -20,7 +20,7 @@ class GitHubClientServiceProvider extends ServiceProvider
                 $githubClient->authenticate(
                     config('services.github.client_id'),
                     config('services.github.client_secret'),
-                    Client::AUTH_URL_CLIENT_ID
+                    Client::AUTH_HTTP_PASSWORD
                 );
             }
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "type": "project",
     "require": {
         "laravel/framework": "5.8.*",
-        "laravel/socialite": "^3.0",
+        "laravel/socialite": "^4.0",
         "michelf/php-markdown": "~1.4",
         "knplabs/github-api": "~1.4",
         "symfony/yaml": "~4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "172db1646d326c6ef7b1e86e02a001b9",
+    "content-hash": "5f1b116e80b2f5645251c11648acd0ce",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -957,34 +957,35 @@
         },
         {
             "name": "laravel/socialite",
-            "version": "v3.3.0",
+            "version": "v4.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/socialite.git",
-                "reference": "79316f36641f1916a50ab14d368acdf1d97e46de"
+                "reference": "4bd66ee416fea04398dee5b8c32d65719a075db4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/socialite/zipball/79316f36641f1916a50ab14d368acdf1d97e46de",
-                "reference": "79316f36641f1916a50ab14d368acdf1d97e46de",
+                "url": "https://api.github.com/repos/laravel/socialite/zipball/4bd66ee416fea04398dee5b8c32d65719a075db4",
+                "reference": "4bd66ee416fea04398dee5b8c32d65719a075db4",
                 "shasum": ""
             },
             "require": {
+                "ext-json": "*",
                 "guzzlehttp/guzzle": "~6.0",
-                "illuminate/contracts": "~5.4",
-                "illuminate/http": "~5.4",
-                "illuminate/support": "~5.4",
+                "illuminate/http": "~5.7.0|~5.8.0|^6.0|^7.0",
+                "illuminate/support": "~5.7.0|~5.8.0|^6.0|^7.0",
                 "league/oauth1-client": "~1.0",
-                "php": ">=5.6.4"
+                "php": "^7.1.3"
             },
             "require-dev": {
-                "mockery/mockery": "~0.9",
-                "phpunit/phpunit": "~4.0|~5.0"
+                "illuminate/contracts": "~5.7.0|~5.8.0|^6.0|^7.0",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^7.0|^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "4.x-dev"
                 },
                 "laravel": {
                     "providers": [
@@ -1016,7 +1017,7 @@
                 "laravel",
                 "oauth"
             ],
-            "time": "2018-12-21T14:06:32+00:00"
+            "time": "2020-02-04T15:30:01+00:00"
         },
         {
             "name": "laravel/tinker",


### PR DESCRIPTION
This PR updates Socialite to the latest 4.* version and updates the `GistClientServiceProvider` and `GithubClientServiceProvider` to use the client id and secret in an `Authorization` header instead of query parameters since GitHub has deprecated that method.

In addition, I updated `AuthorClientServiceProvider` to use a client id and secret instead of a token. I'm not positive about this change but everything seems to be working fine.