### PR TITLE
Updates Travis Build URL to GH actions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-          php-version: 7.2
+          php-version: 7.4
           extensions: posix, dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
           coverage: none
     

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 # GistLog
 
-[![Build Status](https://travis-ci.org/tightenco/gistlog.png?branch=main)](http://travis-ci.org/tightenco/gistlog)
+[![Build Status](https://travis-ci.com/tightenco/gistlog.png?branch=main)](http://travis-ci.com/tightenco/gistlog)
 
 Turn your gists into easy, beautiful, responsive blog posts--a "GistLog". Just paste a Gist URL into [GistLog.co](https://gistlog.co/) and you're up and running.
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 # GistLog
 
-[![Build Status](https://travis-ci.com/tightenco/gistlog.png?branch=main)](http://travis-ci.com/tightenco/gistlog)
+![Build Status](https://github.com/tighten/gistlog/workflows/Build%20and%20Test/badge.svg)
 
 Turn your gists into easy, beautiful, responsive blog posts--a "GistLog". Just paste a Gist URL into [GistLog.co](https://gistlog.co/) and you're up and running.
 


### PR DESCRIPTION
This updates to the correct website so it doesn't show a broken repository in travis, but still shows build status unknown. I don't have access to troubleshoot why the status is unknown but this will at least point to a valid endpoint.