### PR TITLE
Add author bio to author show

### DIFF
--- a/app/Authors/Author.php
+++ b/app/Authors/Author.php
@@ -21,6 +21,8 @@ class Author
 
     public $username;
 
+    public $bio;
+
     /**
      * @var Collection
      */
@@ -40,6 +42,7 @@ class Author
         $author->link = $gitHubUser['html_url'];
         $author->name = Arr::get($gitHubUser, 'name');
         $author->username = $gitHubUser['login'];
+        $author->bio = $gitHubUser['bio'];
 
         $author->gists = collect($gitHubGists)->map(function ($gist) {
             return Gistlog::fromGitHub($gist);
@@ -58,6 +61,7 @@ class Author
         $author->name = 'anonymous';
         $author->username = self::ANONYMOUS_USERNAME;
         $author->gists = collect([]);
+        $author->bio = null;
 
         return $author;
     }

--- a/resources/views/authors/show.blade.php
+++ b/resources/views/authors/show.blade.php
@@ -39,6 +39,12 @@
                 </div>
                 @endforeach
             </section>
+            @if ($author->bio)
+                <section class="my-8 border-t border-gray-400 text-gray-500">
+                    <h2 class="text-xl my-2">Author Bio</h2>
+                    <div>{{ $author->bio }}</div>
+                </section>
+            @endif
         </section>
     </div>
 </div>

--- a/tests/Feature/AuthorPageTest.php
+++ b/tests/Feature/AuthorPageTest.php
@@ -20,7 +20,7 @@ class AuthorPageTest extends TestCase
     }
 
     /** @test */
-    public function a_user_can_visit_the_author_page()
+    public function a_user_can_visit_the_author_page_and_also_see_a_bio()
     {
         $gist1 = $this->createGist([
             'title' => 'My title',
@@ -31,6 +31,7 @@ class AuthorPageTest extends TestCase
 
         $author = $this->createAuthor([
             'name' => 'Matt Stauffer',
+            'bio' => 'My Amazing Bio',
             'gists' => [$gist1, $gist2]
         ]);
 
@@ -45,6 +46,30 @@ class AuthorPageTest extends TestCase
         $response->assertSee('Matt Stauffer');
         $response->assertSee('My title');
         $response->assertSee('My Second title');
+        $response->assertSee('My Amazing Bio');
+    }
+
+    /** @test * */
+    function if_a_user_does_not_set_a_bio_it_hides_the_view()
+    {
+        $gist1 = $this->createGist();
+        $gist2 = $this->createGist();
+
+        $author = $this->createAuthor([
+            'name' => 'Matt Stauffer',
+            'bio' => null,
+            'gists' => [$gist1, $gist2]
+        ]);
+
+        $this->instance(
+            AuthorRepository::class,
+            Mockery::mock(AuthorRepository::class, function (MockInterface $mock) use ($author) {
+                $mock->shouldReceive('findByUsername')->once()->andReturn($author);
+            })
+        );
+        $response = $this->get('/mattstauffer');
+        $response->assertOk();
+        $response->assertDontSee('Author Bio');
     }
 
     public function createAuthor($authorArray = [])
@@ -56,6 +81,7 @@ class AuthorPageTest extends TestCase
         $author->name = $authorArray['name'] ?? $this->faker->name();
         $author->username = $authorArray['username'] ?? $this->faker->username();
         $author->gists = collect($authorArray['gists']) ?? collect([]);
+        $author->bio = $authorArray['bio'];
 
         return $author;
     }


### PR DESCRIPTION
Will show the author's bio on their profile page referencing- https://github.com/tighten/gistlog/issues/180

I'm not sure how I feel about the styling but that should be easy to adjust-

<img width="922" alt="Screen Shot 2021-11-11 at 2 43 24 PM" src="https://user-images.githubusercontent.com/8092154/141359359-e9d0869b-791a-4caf-a22a-fba5948d6ca3.png">


